### PR TITLE
Orca state machine bug fixes

### DIFF
--- a/Tools/scripts/flash_via_remote.sh
+++ b/Tools/scripts/flash_via_remote.sh
@@ -83,7 +83,7 @@ fi
 # Run the uploader.py script on the remote machine
 sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no "$IP_ADDRESS" << EOF
     cd "$REMOTE_DIR"
-    python3 uploader.py ardurover.apj
+    python3 uploader.py ardurover.apj --port /dev/ttyACM0
 EOF
 
 # Check the exit status of the ssh command, if it failed, display error and exit

--- a/Tools/scripts/flash_via_remote.sh
+++ b/Tools/scripts/flash_via_remote.sh
@@ -47,7 +47,7 @@ PASSWORD=$2
 ARDUROVER_DIR=${3:-../../build/CubeOrangePlus/bin}
 
 # Define the remote directory
-REMOTE_DIR="/home/havoc/ardurover_flash"
+REMOTE_DIR="/havoc/ardurover_flash"
 
 # Check if the ARDUROVER_DIR exists and is a directory, if not, display error and exit
 if [ ! -d "$ARDUROVER_DIR" ]; then
@@ -71,8 +71,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # Copy uploader.py and contents of ARDUROVER_DIR to the remote machine
-sshpass -p "$PASSWORD" scp -o StrictHostKeyChecking=no uploader.py "$IP_ADDRESS:$REMOTE_DIR/"
-sshpass -p "$PASSWORD" scp -o StrictHostKeyChecking=no -r "$ARDUROVER_DIR"/* "$IP_ADDRESS:$REMOTE_DIR/"
+sshpass -p "$PASSWORD" scp -O -o StrictHostKeyChecking=no uploader.py "$IP_ADDRESS:$REMOTE_DIR/"
+sshpass -p "$PASSWORD" scp -O -o StrictHostKeyChecking=no -r "$ARDUROVER_DIR"/* "$IP_ADDRESS:$REMOTE_DIR/"
 
 # Check the exit status of the scp commands, if they failed, display error and exit
 if [ $? -ne 0 ]; then

--- a/libraries/AP_IrisOrca/AP_IrisOrca.h
+++ b/libraries/AP_IrisOrca/AP_IrisOrca.h
@@ -282,12 +282,10 @@ namespace orca {
      * 
      * @param[in] rcvd_buff The buffer containing received response data
      * @param[in] buff_len The length of the received buffer
-     * @param[out] state (output parameter) State data of the actuator to populate with response.
-     * Currently only updates the mode.
      * @return true response successfully parsed 
      * @return false response parsing failed
      */
-    bool parse_write_register(uint8_t *rcvd_buff, uint8_t buff_len, ActuatorState &state);
+    bool parse_write_register(uint8_t *rcvd_buff, uint8_t buff_len);
 
     /**
      * @brief Parse the response to a 0x10 Multiple Write Registers message.


### PR DESCRIPTION
These changes attempt to fix a bug where auto-zeroing sometimes completes prematurely on hardware, resulting on actuator calculating zero position as where it started. During testing, this bug still occurs sometimes for unknown reasons, but appears to happen less often. Although the issue is not completely solved, this change introduces a few bug fixes that are worth merging in at this time.
- Reads the actuator state to ensure no errors between the initial sleep state and auto-zero
- If auto-zero fails, it will retry
- Exit to position mode after auto-zero so we have a positive indication of when it has completed vs. been put to sleep by this driver detecting an error

Also updated flash_via_remote script to work on balena machines by specifying serial port, adding -O option to scp, and changing the remote directory to match the folder scheme.