### PR TITLE
Rover(feat): Add ability to disable speed nudge in AUTO, GUIDED modes

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -700,6 +700,15 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(iris_orca, "ORCA_", 58, ParametersG2, AP_IrisOrca),
 #endif
 
+    // @Param: PILOT_SPEED_NUDGE
+    // @DisplayName: Pilot Throttle Speed Nudge
+    // @Description: Enables/Disables pilot speed nudge in GUIDED or AUTO mode.
+    // @Values: 0:Disabled,1:Enabled
+    // @Range: 0 1
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("PILOT_SPEED_NUDGE", 59, ParametersG2, pilot_speed_nudge, 1),
+
     AP_GROUPEND
 };
 

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -436,6 +436,9 @@ public:
     // FS GCS timeout trigger time
     AP_Float fs_gcs_timeout;
 
+    // Pilot guided/auto throttle speed nudge
+    AP_Int8 pilot_speed_nudge;
+
     class ModeCircle mode_circle;
 
 #if HAL_IRISORCA_ENABLED

--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -391,6 +391,11 @@ float Mode::calc_speed_nudge(float target_speed, bool reversed)
         return target_speed;
     }
 
+    // completely disable speed nudge based on parameter
+    if (rover.g2.pilot_speed_nudge == 0) {
+        return target_speed;
+    }
+
     // convert pilot throttle input to speed
     float pilot_steering, pilot_throttle;
     get_pilot_input(pilot_steering, pilot_throttle);


### PR DESCRIPTION
## Overview

In AUTO and GUIDED mode, Rover has a feature where the pilot can bump up the speed using the throttle stick (See https://ardupilot.org/rover/docs/guided-mode.html). 

Because of how we operate our boats, this causes unexpected behavior if a user accidentally has a controller connected and bumps the throttle. In this situation it's not clear that the throttle increase is caused by RC control.

To solve this, I add a parameter `PILOT_SPEED_NUDGE` which can have a value of `0` or `1`. `1`, the default, keeps the nudge on. Setting this to `0` disables the speed nudge entirely.