### PR TITLE
Orca temperature tuning

### DIFF
--- a/libraries/AP_IrisOrca/AP_IrisOrca.cpp
+++ b/libraries/AP_IrisOrca/AP_IrisOrca.cpp
@@ -140,6 +140,9 @@ const AP_Param::GroupInfo AP_IrisOrca::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("T_THR", 12, AP_IrisOrca, _temp_derating_threshold, 50),
 
+    // @param 
+    AP_GROUPINFO("THR_ACT", 13, AP_IrisOrca, _throttle_activate, 0.03f),
+
     AP_GROUPEND
 };
 
@@ -503,7 +506,14 @@ bool AP_IrisOrca::healthy()
 
 uint32_t AP_IrisOrca::get_desired_shaft_pos()
 {
-    const float yaw = constrain_float(SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t::k_steering), -1.0, 1.0);
+    const float throttle = SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t::k_throttle);
+
+    float yaw = constrain_float(SRV_Channels::get_output_norm(SRV_Channel::Aux_servo_function_t::k_steering), -1.0, 1.0);
+
+    if (fabsf(throttle) < _throttle_activate) {
+        yaw = 0.0f;
+    }
+    
 
     const float m = (_reverse_direction ? -1.0 : 1.0) * 0.5 * 1000 * (_max_travel_mm - (2.0 * _pad_travel_mm));
     const float b = 0.5 * 1000 * _max_travel_mm;

--- a/libraries/AP_IrisOrca/AP_IrisOrca.cpp
+++ b/libraries/AP_IrisOrca/AP_IrisOrca.cpp
@@ -346,7 +346,7 @@ async AP_IrisOrca::run()
     WRITE_REGISTER(orca::Register::USER_MAX_FORCE_H, HIGHWORD(0), "IrisOrca: Failed to set max force");
 
     // set comms timeout to 300ms
-    WRITE_REGISTER(orca::Register::USER_COMMS_TIMEOUT, 300, "IrisOrca: Failed to set comms timeout");
+    WRITE_REGISTER(orca::Register::USER_COMMS_TIMEOUT, 500, "IrisOrca: Failed to set comms timeout");
 
     // set auto zero max force
     // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "IrisOrca: Auto zero max force %" PRIi16, _auto_zero_f_max.get());

--- a/libraries/AP_IrisOrca/AP_IrisOrca.h
+++ b/libraries/AP_IrisOrca/AP_IrisOrca.h
@@ -99,6 +99,7 @@ private:
     AP_Int16 _gain_de;                  // position control derivative error gain
     AP_Int16 _auto_zero_f_max;          // maximum force for auto zero in Newtons
     AP_Int8 _temp_derating_threshold;   // temperature threshold in degrees Celsius for derating
+    AP_Float _throttle_activate;        // min throttle to activate steering
 
     AP_HAL::UARTDriver *_uart;
     bool _initialised;


### PR DESCRIPTION
Orca will not move when the throttle is below activation threshold.

New parameter `ORCA_THR_ACT` represents the throttle activation threshold. If the throttle is below this value, the Orca will not move. 

Context: we have very little steering authority when at zero throttle, so it is wasteful to move the Orca. Let's take the opportunity at zero throttle to let the Orca cool down.