### PR TITLE
Apply SPEED_MAX parameter to all modes

### DIFF
--- a/Rover/mode.cpp
+++ b/Rover/mode.cpp
@@ -286,6 +286,12 @@ void Mode::handle_tack_request()
 
 void Mode::calc_throttle(float target_speed, bool avoidance_enabled)
 {
+    // Limit to SPEED_MAX parameter
+    if (is_positive(g2.speed_max)) {
+        if (fabsf(target_speed) > g2.speed_max) {
+            target_speed = copysignf(g2.speed_max, target_speed);
+        }
+    }
     // get acceleration limited target speed
     target_speed = attitude_control.get_desired_speed_accel_limited(target_speed, rover.G_Dt);
 


### PR DESCRIPTION
Applies to SPEED_MAX parameter to clamp in the `calc_throttle` function so that it correctly applies in guided/auto modes.